### PR TITLE
Increase textarea size and rename fallback button

### DIFF
--- a/custom_animation_canvas.html
+++ b/custom_animation_canvas.html
@@ -35,7 +35,8 @@
     #layers li.selected { background: #d0eaff; }
     #paths li.selected { outline: 2px solid #000; }
     #layers button, #paths button { margin-left: 4px; }
-    #codeBox { width: 100%; height: 120px; margin-top: 5px; font-family: monospace; }
+    #codeBox { width: 100%; height: 240px; margin-top: 5px; font-family: monospace; }
+    #fallbackCodeBox { width: 100%; height: 240px; margin-top: 5px; font-family: monospace; }
     #newPathBtn { margin-top: 10px; width: 100%; }
     .section-label { margin-top: 10px; font-weight: bold; }
   </style>
@@ -58,10 +59,10 @@
     <div class="section-label" id="codeLabel">Generated Code:</div>
     <div style="display:flex; gap:5px; margin-bottom:5px;">
       <button id="showLLMCodeBtn" class="code-tab active">LLM Code</button>
-      <button id="showFallbackCodeBtn" class="code-tab">Fallback Code</button>
+      <button id="showFallbackCodeBtn" class="code-tab">local gen code</button>
     </div>
     <textarea id="codeBox" placeholder="LLM generated code will appear here…" style="display:block;"></textarea>
-    <textarea id="fallbackCodeBox" placeholder="Fallback code will appear here…" style="display:none; height:120px;"></textarea>
+    <textarea id="fallbackCodeBox" placeholder="Fallback code will appear here…" style="display:none;"></textarea>
 
     <div style="margin-top:5px;">
       <button id="genBtn" disabled>Generate Code</button>


### PR DESCRIPTION
## Summary
- enlarge code entry areas to 240px and apply the same style to the fallback box
- rename the fallback code tab to `local gen code`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852cec12014832dac3de0c5e7f3012d